### PR TITLE
Add QTradeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Open access: all rights granted for use and re-use of any kind, by anyone, at no
 * [Sentiment and Knowledge Based Algorithmic Trading with Deep Reinforcement Learning](https://arxiv.org/abs/2001.09403) - Abhishek Nan, Anandh Perumal, Osmar R. Zaiane (2020)
 
 # Repositories
+* [squidKid-deluxe/QTradeX](https://github.com/squidKid-deluxe/QTradeX-Algo-Trading-SDK) - A powerful and flexible Python framework for designing, backtesting, optimizing, and deploying algotrading bots
 * [Yvictor/TradingGym](https://github.com/Yvictor/TradingGym) - Trading and Backtesting environment for training reinforcement learning agent or simple rule base algo
 * [Rachnog/Deep-Trading](https://github.com/Rachnog/Deep-Trading) - Experimental time series forecasting
 * [jobvisser03/deep-trading-advisor](https://github.com/jobvisser03/deep-trading-advisor) - Deep Trading Advisor uses MLP, CNN, and RNN+LSTM with Keras, zipline, Dash and Plotly


### PR DESCRIPTION
Hi,

I'd like to introduce QtradeX – a flexible trading engine I co-built with @litepresence that's fully capable of backtesting, optimizing (or training), and deploying neural networks, RL, and other Deep Learning algorithms.

Key Features:
- AI-tuned & open source
- Botscript deployment platform
- Supports Crypto, DeFi, Stocks, Forex, Comex
- Multi-candle backtesting
- Three parameter optimization engines (Quantum PSO, Local search GA, Iterative parametric space expansion)
- Manual optimization GUI
- 50+ backtests per second on modest hardware
- Live trading via CCXT; integration with 100+ exchanges & BitShares DEX
- Data from CCXT, yfinance, cryptocompare, alphavantage, and datafinancereader
- CSV parsing into any candle size, Tulipy indicator integration with 25 custom indicators
- More brokerages, data sources, and indicators coming soon

Resources:
- SDK: https://github.com/squidKid-deluxe/QTradeX-Algo-Trading-SDK
- Bots: https://github.com/squidKid-deluxe/QTradeX-AI-Agents
- Docs: https://deepwiki.com/squidKid-deluxe/QTradeX-Algo-Trading-SDK | https://deepwiki.com/squidKid-deluxe/QTradeX-AI-Agents
- AMA: https://t.me/qtradex_sdk