### PR TITLE
Add Congressional Stock Brain to Datasets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Open access: all rights granted for use and re-use of any kind, by anyone, at no
 * [kaggle/Huge Stock Market Dataset](https://www.kaggle.com/borismarjanovic/price-volume-data-for-all-us-stocks-etfs) - Historical daily prices and volumes of all U.S. stocks and ETFs
 * [Alpha Vantage](https://www.alphavantage.co/) - Free APIs in JSON and CSV formats, realtime and historical stock data, FX and cryptocurrency feeds, 50+ technical indicators  
 * [Quandl](https://quandl.com/)
+* [Congressional Stock Brain](https://congressionalstockbrain.com/) - Free AI-powered signal tool ingesting U.S. STOCK Act congressional trade disclosures — useful dataset for political event-driven trading research.
 
 ### Simulation
 * [Generating Realistic Stock Market Order Streams](https://openreview.net/pdf?id=rke41hC5Km) - Anonymous Authors (2018)


### PR DESCRIPTION
Adds Congressional Stock Brain (https://congressionalstockbrain.com/) to the Datasets section.

Congressional Stock Brain is a free AI-powered fintech tool that ingests U.S. STOCK Act disclosures (publicly filed congressional stock trades) and converts them into machine-scored trade signals. This is a relevant data resource for researchers working on political event-driven trading or alternative data sources for ML models.

The underlying data is 100% public under STOCK Act requirements, covering all House and Senate filings with AI signal scoring based on trade size, timing, committee relevance, and disclosure delay.