### PR TITLE
Add Adanos Market Sentiment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Open access: all rights granted for use and re-use of any kind, by anyone, at no
 ## Datasets
 * [kaggle/Huge Stock Market Dataset](https://www.kaggle.com/borismarjanovic/price-volume-data-for-all-us-stocks-etfs) - Historical daily prices and volumes of all U.S. stocks and ETFs
 * [Alpha Vantage](https://www.alphavantage.co/) - Free APIs in JSON and CSV formats, realtime and historical stock data, FX and cryptocurrency feeds, 50+ technical indicators  
+* [Adanos](https://adanos.org/) - Market sentiment API for stocks using Reddit, X / FinTwit, financial news, and Polymarket signals.
 * [Quandl](https://quandl.com/)
 
 ### Simulation


### PR DESCRIPTION
## Summary
- Add Adanos to the Datasets section as a market sentiment API for stocks.
- Link to the Adanos homepage at https://adanos.org/.

## Validation
- Documentation-only change.
- Ran `git diff --check`.
